### PR TITLE
Nav item flexibility

### DIFF
--- a/addon/components/mdl-nav-item.js
+++ b/addon/components/mdl-nav-item.js
@@ -3,5 +3,7 @@ import ChildComponentSupport from 'ember-composability/mixins/child-component-su
 import MdlNav from './mdl-nav';
 
 export default Ember.Component.extend(ChildComponentSupport, {
-  _parentComponentTypes: Ember.A([MdlNav])
+  _parentComponentTypes: Ember.A([MdlNav]),
+  inDrawer: true,
+  inHeader: true
 });

--- a/addon/components/mdl-nav.js
+++ b/addon/components/mdl-nav.js
@@ -25,6 +25,17 @@ export default BaseComponent.extend(ParentComponentSupport, {
   includeDrawer: true,
   includeDrawerTitle: true,
   _mdlComponent: null,
+  _drawerNavItems: _computed('_childComponents.[]', '_childComponents.@each.inDrawer', {
+    get() {
+      return this.get('_childComponents').filterBy('inDrawer', true);
+    }
+  }),
+  _headerNavItems: _computed('_childComponents.[]', '_childComponents.@each.inHeader', {
+    get() {
+      return this.get('_childComponents').filterBy('inHeader', true);
+    }
+  }),
+
   _headerClassString: _computed('waterfallMenu', {
     get() {
       let classes = ['mdl-layout__header'];

--- a/addon/components/mdl-nav.js
+++ b/addon/components/mdl-nav.js
@@ -27,12 +27,12 @@ export default BaseComponent.extend(ParentComponentSupport, {
   _mdlComponent: null,
   _drawerNavItems: _computed('_childComponents.[]', '_childComponents.@each.inDrawer', {
     get() {
-      return this.get('_childComponents').filterBy('inDrawer', true);
+      return Ember.A(this.get('_childComponents').filterBy('inDrawer', true));
     }
   }),
   _headerNavItems: _computed('_childComponents.[]', '_childComponents.@each.inHeader', {
     get() {
-      return this.get('_childComponents').filterBy('inHeader', true);
+      return Ember.A(this.get('_childComponents').filterBy('inHeader', true));
     }
   }),
 

--- a/addon/templates/components/mdl-nav.hbs
+++ b/addon/templates/components/mdl-nav.hbs
@@ -5,7 +5,7 @@
     <div class="mdl-layout-spacer"></div>
     {{#if includeHeaderLinks}}
     <nav class="mdl-navigation mdl-layout--large-screen-only">
-      {{#each _childComponents as |navItem|}}
+      {{#each _headerNavItems as |navItem|}}
         {{link-to navItem.name navItem.route class='mdl-navigation__link'}}
       {{/each}}
     </nav>
@@ -19,7 +19,7 @@
   <span class="mdl-layout-title">{{mobileTitle}}</span>
   {{/if}}
   <nav class="mdl-navigation">
-    {{#each _childComponents as |navItem|}}
+    {{#each _drawerNavItems as |navItem|}}
       {{link-to navItem.name navItem.route class='mdl-navigation__link'}}
     {{/each}}
   </nav>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-material-lite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Material Design Lite for Ember.js Apps",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/components/x-nav.js
+++ b/tests/dummy/app/components/x-nav.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import Nav from 'ember-material-lite/components/mdl-nav';
+import layout from '../templates/components/x-nav';
+
+export default Nav.extend({
+  layout
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -17,7 +17,9 @@ body {
 @media (max-width: 600px) {
   .x-example {
     width: 100%;
-
+  }
+  .mdl-layout__drawer .mdl-navigation .mdl-navigation__link.github-link.drawer {
+    display: inherit;
   }
 }
 
@@ -64,3 +66,26 @@ body {
 .white-text {
   color: #fff;
 }
+
+.mdl-layout__drawer .mdl-navigation .mdl-navigation__link.github-link,
+.mdl-layout__header-row .mdl-navigation .mdl-navigation__link.github-link {
+  &.drawer {
+    display: none;
+    .material-icons {
+      top: -3px;
+    }
+  }
+  .material-icons {
+    position: relative;
+    top: 7px;
+  }
+}
+@media (max-width: 600px) {
+  .x-example {
+    width: 100%;
+  }
+  .mdl-layout__drawer .mdl-navigation .mdl-navigation__link.github-link.drawer {
+    display: inherit;
+  }
+}
+

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{#mdl-nav title='Ember Material Design Lite'
+{{#x-nav title='Ember Material Design Lite'
   mobileTitle='Ember MDL'
   includeHeaderItems=false
   includeDrawerTitle=false
@@ -22,4 +22,4 @@
 
     {{outlet}}
   </div>
-{{/mdl-nav}}
+{{/x-nav}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,20 +4,20 @@
   includeDrawerTitle=false
   fixedHeader=true
   fixedDrawer=true}}
-    {{mdl-nav-item name='Badges'    route='badges'}}
-    {{mdl-nav-item name='Buttons'   route='buttons'}}
-    {{mdl-nav-item name='Cards'     route='cards'}}
-    {{mdl-nav-item name='Footers'   route='footer'}}
-    {{mdl-nav-item name='Icons'     route='icons'}}
-    {{mdl-nav-item name='Inputs'    route='textfields'}}
-    {{mdl-nav-item name='Menus'     route='menus'}}
-    {{mdl-nav-item name='Nav'       route='navs'}}
-    {{mdl-nav-item name='Progress'  route='progress'}}
-    {{mdl-nav-item name='Sliders'   route='sliders'}}
-    {{mdl-nav-item name='Table'     route='table'}}
-    {{mdl-nav-item name='Tabs'      route='tabs'}}
-    {{mdl-nav-item name='Toggles'   route='toggles'}}
-    {{mdl-nav-item name='Tooltips'  route='tooltips'}}
+    {{mdl-nav-item name='Badges'    inHeader=false route='badges'}}
+    {{mdl-nav-item name='Buttons'   inHeader=false route='buttons'}}
+    {{mdl-nav-item name='Cards'     inHeader=false route='cards'}}
+    {{mdl-nav-item name='Footers'   inHeader=false route='footer'}}
+    {{mdl-nav-item name='Icons'     inHeader=false route='icons'}}
+    {{mdl-nav-item name='Inputs'    inHeader=false route='textfields'}}
+    {{mdl-nav-item name='Menus'     inHeader=false route='menus'}}
+    {{mdl-nav-item name='Nav'       inHeader=false route='navs'}}
+    {{mdl-nav-item name='Progress'  inHeader=false route='progress'}}
+    {{mdl-nav-item name='Sliders'   inHeader=false route='sliders'}}
+    {{mdl-nav-item name='Table'     inHeader=false route='table'}}
+    {{mdl-nav-item name='Tabs'      inHeader=false route='tabs'}}
+    {{mdl-nav-item name='Toggles'   inHeader=false route='toggles'}}
+    {{mdl-nav-item name='Tooltips'  inHeader=false route='tooltips'}}
   <div class="mdl-grid">
 
     {{outlet}}

--- a/tests/dummy/app/templates/components/x-nav.hbs
+++ b/tests/dummy/app/templates/components/x-nav.hbs
@@ -1,0 +1,40 @@
+{{#if includeHeader}}
+<header class={{_headerClassString}}>
+  <div class="mdl-layout__header-row">
+    <span class="mdl-layout-title">{{title}}</span>
+    <div class="mdl-layout-spacer"></div>
+    {{#if includeHeaderLinks}}
+    <nav class="mdl-navigation mdl-layout--large-screen-only">
+      {{#each _headerNavItems as |navItem|}}
+        {{link-to navItem.name navItem.route class='mdl-navigation__link'}}
+      {{/each}}
+      <a class='mdl-navigation__link github-link' href='https://github.com/truenorth/ember-material-lite' target='_blank'>
+        <i class="material-icons">code</i>
+        GitHub
+      </a>
+    </nav>
+    {{/if}}
+  </div>
+</header>
+{{/if}}
+{{#if includeDrawer}}
+<div class="mdl-layout__drawer">
+  {{#if includeDrawerTitle}}
+    <span class="mdl-layout-title">{{mobileTitle}}</span>
+  {{/if}}
+  <nav class="mdl-navigation">
+    {{#each _drawerNavItems as |navItem|}}
+      {{link-to navItem.name navItem.route class='mdl-navigation__link'}}
+    {{/each}}
+    <a class='mdl-navigation__link github-link drawer' href='https://github.com/truenorth/ember-material-lite' target='_blank'>
+        <i class="material-icons">code</i>
+        GitHub
+      </a>
+  </nav>
+</div>
+{{/if}}
+<main class="mdl-layout__content">
+  <div class="page-content">
+    {{yield}}
+  </div>
+</main>

--- a/tests/dummy/app/templates/snippets/mdl-nav-fixed-drawer.hbs
+++ b/tests/dummy/app/templates/snippets/mdl-nav-fixed-drawer.hbs
@@ -2,14 +2,14 @@
   title='Fixed Drawer Example'
   fixedDrawer=true
   mobileTitle='Fixed Drawer'}}
-  {{mdl-nav-item name='Buttons'   route='buttons'}}
-  {{mdl-nav-item name='Tabs'      route='tabs'}}
-  {{mdl-nav-item name='Nav'       route='navs'}}
+  {{mdl-nav-item name='Buttons' route='buttons' inHeader=false}}
+  {{mdl-nav-item name='Tabs'    route='tabs'    inDrawer=false}}
+  {{mdl-nav-item name='Nav'     route='navs'}}
   <div class="mdl-grid">
-  	<div class="mdl-cell mdl-cell--12-col">
+    <div class="mdl-cell mdl-cell--12-col">
     Bacon ipsum dolor amet pork loin cow pancetta, t-bone leberkas jerky pork belly. Corned beef kielbasa t-bone, ham prosciutto ribeye chicken filet mignon pork loin turducken flank short ribs beef pancetta kevin. Swine pancetta salami frankfurter alcatra filet mignon. Bresaola pastrami hamburger turkey short loin. Andouille pig turducken, pork chop ham tongue pork capicola. Swine venison brisket, pork belly turkey doner chicken rump short loin.
-	Tail shoulder cupim, tenderloin bacon short ribs ball tip alcatra sirloin ground round salami spare ribs kevin. Ground round meatball chuck kevin sirloin jerky tail ham. Filet mignon beef brisket boudin ball tip meatloaf shank. Tail tri-tip shankle bacon short ribs pork chop fatback cupim prosciutto andouille sausage turducken chicken filet mignon. Salami jowl fatback shank spare ribs. Boudin ground round ham, ball tip meatloaf tenderloin beef.
-	Fatback flank ball tip corned beef. Ball tip spare ribs kielbasa bresaola turkey venison salami leberkas chicken jerky picanha sausage pork. Shoulder doner frankfurter jerky corned beef, alcatra beef ribs venison flank brisket short loin. Pastrami porchetta shoulder, short ribs ground round jowl doner meatball meatloaf sirloin. Capicola leberkas jowl, sausage pancetta chuck ham hock swine tail pork chop venison porchetta jerky brisket. Pig shankle filet mignon shank meatball. Prosciutto drumstick leberkas spare ribs, bacon ball tip pork chop hamburger t-bone.
-	</div>
+  Tail shoulder cupim, tenderloin bacon short ribs ball tip alcatra sirloin ground round salami spare ribs kevin. Ground round meatball chuck kevin sirloin jerky tail ham. Filet mignon beef brisket boudin ball tip meatloaf shank. Tail tri-tip shankle bacon short ribs pork chop fatback cupim prosciutto andouille sausage turducken chicken filet mignon. Salami jowl fatback shank spare ribs. Boudin ground round ham, ball tip meatloaf tenderloin beef.
+  Fatback flank ball tip corned beef. Ball tip spare ribs kielbasa bresaola turkey venison salami leberkas chicken jerky picanha sausage pork. Shoulder doner frankfurter jerky corned beef, alcatra beef ribs venison flank brisket short loin. Pastrami porchetta shoulder, short ribs ground round jowl doner meatball meatloaf sirloin. Capicola leberkas jowl, sausage pancetta chuck ham hock swine tail pork chop venison porchetta jerky brisket. Pig shankle filet mignon shank meatball. Prosciutto drumstick leberkas spare ribs, bacon ball tip pork chop hamburger t-bone.
+  </div>
   </div>
 {{/mdl-nav}}


### PR DESCRIPTION
Nav menu items can now be placed in either the header, the drawer, or both. 

Example:

```handlebars
  {{mdl-nav-item name='Buttons' route='buttons' inHeader=false}}
  {{mdl-nav-item name='Tabs'    route='tabs'    inDrawer=false}}
  {{mdl-nav-item name='Nav'     route='navs'}}
```

<img width="866" alt="screen shot 2015-07-26 at 1 56 43 pm" src="https://cloud.githubusercontent.com/assets/558005/8895877/2e9386ea-339e-11e5-916b-97930899d50e.png">
